### PR TITLE
Sample project import fails silently when using Eclipse/ADT Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Logically, the sample application doesn't include API keys. In order to run the 
 
 	<meta-data
 	    android:name="com.google.android.maps.v2.API_KEY"
-	    android:value="<your_key_here>" />
+	    android:value="your_key_here" />
 
 
 Developed By

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -32,7 +32,7 @@
         android:hardwareAccelerated="true">
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="<your_key_here>" />
+            android:value="your_key_here" />
 
         <activity android:name=".MainActivity">
             <intent-filter>


### PR DESCRIPTION
The sample project will silently fail to import when using _New - Android Project From Existing Code_ due to the manifest parser exception: `The value of attribute "android:value" associated with an element type "null" must not contain the '<' character`.

Removing the '<' and '>' characters from the meta-data tag's value placeholder fixes this.
