### PR TITLE
Marker.equals() is always invalid

### DIFF
--- a/library/src/com/cyrilmottier/polaris2/maps/model/Marker.java
+++ b/library/src/com/cyrilmottier/polaris2/maps/model/Marker.java
@@ -45,7 +45,7 @@ public final class Marker {
             return false;
         }
 
-        return !mOriginal.equals(((Marker) other).mOriginal);
+        return mOriginal.equals(((Marker) other).mOriginal);
     }
 
     @Override


### PR DESCRIPTION
The equality test is backwards.
